### PR TITLE
Fix tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,28 +34,31 @@ module "example_redis" {
 
 ## Input
 
-|  Name                        |  Default            |  Description                                           |
-|:-----------------------------|:-------------------:|:-------------------------------------------------------|
-| namespace                    |global               |Namespace                                               |
-| stage                        |default              |Stage                                                   |
-| name                         |redis                |Name                                                    |
-| security_groups              |[]                   |AWS security group ids                                  |
-| vpc_id                       |__REQUIRED__         |AWS VPC id                                              |
-| subnets                      | []                  | AWS subnet ids                                         |
-| cluster_size                 | 1                   | Count of nodes in cluster                              |
-| instance_type                | cache.t2.micro      | Elastic cache instance type                            |
-| family                       | redis3.2            | Redis family                                           |
-| engine_version               | 3.2.4               | Redis engine version                                   |
-| port                         | 6379                | Redis port                                             |
-| maintenance_window           | wed:03:00-wed:04:00 | Maintenance window                                     |
-| notification_topic_arn       |                     | Notification topic arn                                 |
-| alarm_cpu_threshold_percent  | 75                  | CPU threshold alarm level                              |
-| alarm_memory_threshold_bytes | 10000000            | Ram threshold alarm level                              |
-| alarm_actions                | []                  | Alarm action list                                      |
-| apply_immediately            | true                | Apply changes immediately                              |
-| automatic_failover           | false               | Automatic failover (Not available for T1/T2 instances) |
-| availability_zones           | []                  | Availability zone ids                                  |
-| zone_id                      | false               | Route53 dns zone id                                    |
+|  Name                        |  Default            |  Description                                                    |
+|:-----------------------------|:-------------------:|:----------------------------------------------------------------|
+| namespace                    | global              | Namespace                                                       |
+| stage                        | default             | Stage                                                           |
+| name                         | redis               | Name                                                            |
+| security_groups              | []                  | AWS security group ids                                          |
+| vpc_id                       | __REQUIRED__        | AWS VPC id                                                      |
+| subnets                      | []                  | AWS subnet ids                                                  |
+| cluster_size                 | 1                   | Count of nodes in cluster                                       |
+| instance_type                | cache.t2.micro      | Elastic cache instance type                                     |
+| family                       | redis3.2            | Redis family                                                    |
+| engine_version               | 3.2.4               | Redis engine version                                            |
+| port                         | 6379                | Redis port                                                      |
+| maintenance_window           | wed:03:00-wed:04:00 | Maintenance window                                              |
+| notification_topic_arn       |                     | Notification topic arn                                          |
+| alarm_cpu_threshold_percent  | 75                  | CPU threshold alarm level                                       |
+| alarm_memory_threshold_bytes | 10000000            | Ram threshold alarm level                                       |
+| alarm_actions                | []                  | Alarm action list                                               |
+| apply_immediately            | true                | Apply changes immediately                                       |
+| automatic_failover           | false               | Automatic failover (Not available for T1/T2 instances)          |
+| availability_zones           | []                  | Availability zone ids                                           |
+| zone_id                      | false               | Route53 DNS Zone id                                             |
+| attributes                   | []                  | Additional attributes (_e.g._ "1")                              |
+| tags                         | {}                  | Additional tags (_e.g._ map("BusinessUnit","ABC")               |
+| delimiter                    | -                   | Delimiter between `name`, `namespace`, `stage` and `attributes` |
 
 
 ## Output

--- a/main.tf
+++ b/main.tf
@@ -81,7 +81,6 @@ resource "aws_cloudwatch_metric_alarm" "cache_cpu" {
 
   alarm_actions = ["${var.alarm_actions}"]
   depends_on    = ["aws_elasticache_replication_group.default"]
-  tags          = "${module.label.tags}"
 }
 
 resource "aws_cloudwatch_metric_alarm" "cache_memory" {
@@ -102,7 +101,6 @@ resource "aws_cloudwatch_metric_alarm" "cache_memory" {
 
   alarm_actions = ["${var.alarm_actions}"]
   depends_on    = ["aws_elasticache_replication_group.default"]
-  tags          = "${module.label.tags}"
 }
 
 module "dns" {

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 # Define composite variables for resources
 module "label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.2.1"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.2.2"
   namespace  = "${var.namespace}"
   name       = "${var.name}"
   stage      = "${var.stage}"


### PR DESCRIPTION
## what
* Removed `tags` from `aws_cloudwatch_metric_alarm`
* Updated `README`

## why
* `aws_cloudwatch_metric_alarm` does not have `tags` attribute

## references
* https://www.terraform.io/docs/providers/aws/r/cloudwatch_metric_alarm.html
