### PR TITLE
Adding engine_version to elasticache replication group arguments

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -61,6 +61,7 @@ resource "aws_elasticache_replication_group" "default" {
   security_group_ids            = ["${aws_security_group.default.id}"]
   maintenance_window            = "${var.maintenance_window}"
   notification_topic_arn        = "${var.notification_topic_arn}"
+  engine_version                = "${var.engine_version}"
 
   tags = "${module.label.tags}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -45,7 +45,7 @@ variable "instance_type" {
 }
 
 variable "family" {
-  default = "redis3.2"
+  default = "redis4.0"
 }
 
 variable "engine_version" {

--- a/variables.tf
+++ b/variables.tf
@@ -49,7 +49,7 @@ variable "family" {
 }
 
 variable "engine_version" {
-  default = "3.2.4"
+  default = "4.0.10"
 }
 
 variable "notification_topic_arn" {


### PR DESCRIPTION
## What it is

Adds `engine_version` argument to the aws_elasticache_replication_group module.

## Why 

Previously when referencing this module in an external terraform template any attempt to override the engine version was ignored because this option was unavailable. This resulted in AWS utilizing the default Redis engine (4.0), if attempting to make a cluster utilizing an older version of Redis (ex: 3.2.4) and referencing a parameter group using the family redis3.2 Terraform returns an error stating `Error creating Elasticache Replication Group: InvalidParameterCombination: Expected a parameter group of family redis4.0 but found one of family redis3.2`.

## How I tested

Referenced this branch as the source of the module and used the variable `engine_version` to set to my desired engine version, spun up a cluster.