### PR TITLE
Fix bug with dns zone

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -118,7 +118,7 @@ resource "aws_cloudwatch_metric_alarm" "cache_memory" {
 
 module "dns" {
   source    = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.2.1"
-  enabled   = "${var.enabled}"
+  enabled   = "${var.enabled == "true" && var.zone_id != "false"}"
   namespace = "${var.namespace}"
   name      = "${var.name}"
   stage     = "${var.stage}"


### PR DESCRIPTION
## What it is

- Addresses https://github.com/cloudposse/terraform-aws-elasticache-redis/issues/19

## Why

If you don't require a DNS record to be created the previous default for the `zone_id` variable would still trigger a resource to be created, then cause the run to fail because the "false" zone_id doesn't exist. 