### PR TITLE
normalize disable method

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Available targets:
 | tags | Additional tags (_e.g._ map("BusinessUnit","ABC") | map | `<map>` | no |
 | transit_encryption_enabled | Enable TLS | string | `true` | no |
 | vpc_id | AWS VPC id | string | `REQUIRED` | no |
-| zone_id | Route53 DNS Zone id | string | `false` | no |
+| zone_id | Route53 DNS Zone id | string | `` | no |
 
 ## Outputs
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -30,7 +30,7 @@
 | tags | Additional tags (_e.g._ map("BusinessUnit","ABC") | map | `<map>` | no |
 | transit_encryption_enabled | Enable TLS | string | `true` | no |
 | vpc_id | AWS VPC id | string | `REQUIRED` | no |
-| zone_id | Route53 DNS Zone id | string | `false` | no |
+| zone_id | Route53 DNS Zone id | string | `` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -118,7 +118,7 @@ resource "aws_cloudwatch_metric_alarm" "cache_memory" {
 
 module "dns" {
   source    = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.2.1"
-  enabled   = "${var.enabled == "true" && var.zone_id != "false"}"
+  enabled   = "${var.enabled == "true" && length(var.zone_id) > 0 ? "true" : "false"}"
   namespace = "${var.namespace}"
   name      = "${var.name}"
   stage     = "${var.stage}"

--- a/variables.tf
+++ b/variables.tf
@@ -120,7 +120,7 @@ variable "availability_zones" {
 }
 
 variable "zone_id" {
-  default     = "false"
+  default     = ""
   description = "Route53 DNS Zone id"
 }
 


### PR DESCRIPTION
## What it is

- Switch `zone_id` variable default to empty string
- Switch dns module to check length of zone_id variable

## Why

Normalize patterns to match existing modules

Addresses: https://github.com/cloudposse/terraform-aws-elasticache-redis/issues/26