### PR TITLE
Add Optional `elasticache_subnet_group`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ install:
   - make init
 
 script:
-  - make terraform:install
-  - make terraform:get-plugins
-  - make terraform:get-modules
-  - make terraform:lint
-  - make terraform:validate
+  - make terraform/install
+  - make terraform/get-plugins
+  - make terraform/get-modules
+  - make terraform/lint
+  - make terraform/validate

--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2017 Cloud Posse, LLC
+   Copyright 2017-2019 Cloud Posse, LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ We literally have [*hundreds of terraform modules*][terraform_modules] that are 
 
 ## Usage
 
-Include this repository as a module in your existing terraform code:
+**IMPORTANT:** Using the `master` branch in the module `source` is just an example. Do not pin to `master` in your code because there may be breaking changes between releases. Instead pin to the release tag (e.g. `?ref=tags/x.y.z`) of one of our [latest releases](https://github.com/cloudposse/terraform-aws-elasticache-redis/releases).
 
 ```hcl
 // Generate a random string for auth token, no special chars
@@ -98,7 +98,6 @@ Available targets:
   lint                                Lint terraform code
 
 ```
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -114,7 +113,7 @@ Available targets:
 | availability_zones | Availability zone ids | list | `<list>` | no |
 | cluster_size | Count of nodes in cluster | string | `1` | no |
 | delimiter | Delimiter between `name`, `namespace`, `stage` and `attributes` | string | `-` | no |
-| elasticache_subnet_group | Subnet group ID for the Elastic cache instance | string | `` | no |
+| elasticache_subnet_group_name | Subnet group ID for the ElastiCache instance | string | `` | no |
 | enabled | Set to false to prevent the module from creating any resources | string | `true` | no |
 | engine_version | Redis engine version | string | `4.0.10` | no |
 | family | Redis family | string | `redis4.0` | no |
@@ -140,9 +139,9 @@ Available targets:
 | Name | Description |
 |------|-------------|
 | host | Redis host |
-| id | Redis cluster id |
+| id | Redis cluster ID |
 | port | Redis port |
-| security_group_id | Security group id |
+| security_group_id | Security group ID |
 
 
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,11 @@ We literally have [*hundreds of terraform modules*][terraform_modules] that are 
 
 ## Usage
 
-**IMPORTANT:** Using the `master` branch in the module `source` is just an example. Do not pin to `master` in your code because there may be breaking changes between releases. Instead pin to the release tag (e.g. `?ref=tags/x.y.z`) of one of our [latest releases](https://github.com/cloudposse/terraform-aws-elasticache-redis/releases).
+
+**IMPORTANT:** The `master` branch is used in `source` just as an example. In your code, do not pin to `master` because there may be breaking changes between releases.
+Instead pin to the release tag (e.g. `?ref=tags/x.y.z`) of one of our [latest releases](https://github.com/cloudposse/terraform-aws-elasticache-redis/releases).
+
+
 
 ```hcl
 // Generate a random string for auth token, no special chars
@@ -113,7 +117,7 @@ Available targets:
 | availability_zones | Availability zone ids | list | `<list>` | no |
 | cluster_size | Count of nodes in cluster | string | `1` | no |
 | delimiter | Delimiter between `name`, `namespace`, `stage` and `attributes` | string | `-` | no |
-| elasticache_subnet_group_name | Subnet group ID for the ElastiCache instance | string | `` | no |
+| elasticache_subnet_group_name | Subnet group name for the ElastiCache instance | string | `` | no |
 | enabled | Set to false to prevent the module from creating any resources | string | `true` | no |
 | engine_version | Redis engine version | string | `4.0.10` | no |
 | family | Redis family | string | `redis4.0` | no |
@@ -128,10 +132,10 @@ Available targets:
 | replication_group_id | Replication group ID with the following constraints:  A name must contain from 1 to 20 alphanumeric characters or hyphens.   The first character must be a letter.   A name cannot end with a hyphen or contain two consecutive hyphens. | string | `` | no |
 | security_groups | AWS security group ids | list | `<list>` | no |
 | stage | Stage | string | `default` | no |
-| subnets | AWS subnet ids | list | `<list>` | no |
+| subnets | AWS subnet IDs | list | `<list>` | no |
 | tags | Additional tags (_e.g._ map("BusinessUnit","ABC") | map | `<map>` | no |
 | transit_encryption_enabled | Enable TLS | string | `true` | no |
-| vpc_id | AWS VPC id | string | `REQUIRED` | no |
+| vpc_id | AWS VPC id | string | - | yes |
 | zone_id | Route53 DNS Zone id | string | `` | no |
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Available targets:
   lint                                Lint terraform code
 
 ```
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -113,6 +114,7 @@ Available targets:
 | availability_zones | Availability zone ids | list | `<list>` | no |
 | cluster_size | Count of nodes in cluster | string | `1` | no |
 | delimiter | Delimiter between `name`, `namespace`, `stage` and `attributes` | string | `-` | no |
+| elasticache_subnet_group | Subnet group ID for the Elastic cache instance | string | `` | no |
 | enabled | Set to false to prevent the module from creating any resources | string | `true` | no |
 | engine_version | Redis engine version | string | `4.0.10` | no |
 | family | Redis family | string | `redis4.0` | no |
@@ -207,7 +209,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyright
 
-Copyright © 2017-2018 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2019 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 

--- a/README.yaml
+++ b/README.yaml
@@ -48,7 +48,6 @@ description: |-
 
 # How to use this project
 usage: |-
-  **IMPORTANT:** Using the `master` branch in the module `source` is just an example. Do not pin to `master` in your code because there may be breaking changes between releases. Instead pin to the release tag (e.g. `?ref=tags/x.y.z`) of one of our [latest releases](https://github.com/cloudposse/terraform-aws-elasticache-redis/releases).
 
   ```hcl
   // Generate a random string for auth token, no special chars

--- a/README.yaml
+++ b/README.yaml
@@ -48,7 +48,7 @@ description: |-
 
 # How to use this project
 usage: |-
-  Include this repository as a module in your existing terraform code:
+  **IMPORTANT:** Using the `master` branch in the module `source` is just an example. Do not pin to `master` in your code because there may be breaking changes between releases. Instead pin to the release tag (e.g. `?ref=tags/x.y.z`) of one of our [latest releases](https://github.com/cloudposse/terraform-aws-elasticache-redis/releases).
 
   ```hcl
   // Generate a random string for auth token, no special chars

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -13,7 +13,7 @@
 | availability_zones | Availability zone ids | list | `<list>` | no |
 | cluster_size | Count of nodes in cluster | string | `1` | no |
 | delimiter | Delimiter between `name`, `namespace`, `stage` and `attributes` | string | `-` | no |
-| elasticache_subnet_group_name | Subnet group ID for the ElastiCache instance | string | `` | no |
+| elasticache_subnet_group_name | Subnet group name for the ElastiCache instance | string | `` | no |
 | enabled | Set to false to prevent the module from creating any resources | string | `true` | no |
 | engine_version | Redis engine version | string | `4.0.10` | no |
 | family | Redis family | string | `redis4.0` | no |
@@ -28,10 +28,10 @@
 | replication_group_id | Replication group ID with the following constraints:  A name must contain from 1 to 20 alphanumeric characters or hyphens.   The first character must be a letter.   A name cannot end with a hyphen or contain two consecutive hyphens. | string | `` | no |
 | security_groups | AWS security group ids | list | `<list>` | no |
 | stage | Stage | string | `default` | no |
-| subnets | AWS subnet ids | list | `<list>` | no |
+| subnets | AWS subnet IDs | list | `<list>` | no |
 | tags | Additional tags (_e.g._ map("BusinessUnit","ABC") | map | `<map>` | no |
 | transit_encryption_enabled | Enable TLS | string | `true` | no |
-| vpc_id | AWS VPC id | string | `REQUIRED` | no |
+| vpc_id | AWS VPC id | string | - | yes |
 | zone_id | Route53 DNS Zone id | string | `` | no |
 
 ## Outputs

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,4 +1,3 @@
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -14,7 +13,7 @@
 | availability_zones | Availability zone ids | list | `<list>` | no |
 | cluster_size | Count of nodes in cluster | string | `1` | no |
 | delimiter | Delimiter between `name`, `namespace`, `stage` and `attributes` | string | `-` | no |
-| elasticache_subnet_group | Subnet group ID for the Elastic cache instance | string | `` | no |
+| elasticache_subnet_group_name | Subnet group ID for the ElastiCache instance | string | `` | no |
 | enabled | Set to false to prevent the module from creating any resources | string | `true` | no |
 | engine_version | Redis engine version | string | `4.0.10` | no |
 | family | Redis family | string | `redis4.0` | no |
@@ -40,7 +39,7 @@
 | Name | Description |
 |------|-------------|
 | host | Redis host |
-| id | Redis cluster id |
+| id | Redis cluster ID |
 | port | Redis port |
-| security_group_id | Security group id |
+| security_group_id | Security group ID |
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,3 +1,4 @@
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -13,6 +14,7 @@
 | availability_zones | Availability zone ids | list | `<list>` | no |
 | cluster_size | Count of nodes in cluster | string | `1` | no |
 | delimiter | Delimiter between `name`, `namespace`, `stage` and `attributes` | string | `-` | no |
+| elasticache_subnet_group | Subnet group ID for the Elastic cache instance | string | `` | no |
 | enabled | Set to false to prevent the module from creating any resources | string | `true` | no |
 | engine_version | Redis engine version | string | `4.0.10` | no |
 | family | Redis family | string | `redis4.0` | no |

--- a/examples/simple/terraform.tfvars
+++ b/examples/simple/terraform.tfvars
@@ -1,6 +1,11 @@
 namespace = "eg"
+
 name = "redis"
+
 stage = "testing"
+
 zone_id = "Z3SO0TKDDQ0RGG"
+
 region = "us-west-2"
+
 availability_zones = ["us-west-2a", "us-west-2b"]

--- a/main.tf
+++ b/main.tf
@@ -40,7 +40,7 @@ locals {
 }
 
 resource "aws_elasticache_subnet_group" "default" {
-  count      = "${var.enabled == "true" && length(var.subnets) > 0 ? 1 : 0}"
+  count      = "${var.enabled == "true" && var.elasticache_subnet_group_name == "" && length(var.subnets) > 0 ? 1 : 0}"
   name       = "${module.label.id}"
   subnet_ids = ["${var.subnets}"]
 }
@@ -123,7 +123,7 @@ resource "aws_cloudwatch_metric_alarm" "cache_memory" {
 }
 
 module "dns" {
-  source    = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.2.1"
+  source    = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.2.6"
   enabled   = "${var.enabled == "true" && length(var.zone_id) > 0 ? "true" : "false"}"
   namespace = "${var.namespace}"
   name      = "${var.name}"

--- a/main.tf
+++ b/main.tf
@@ -36,7 +36,7 @@ resource "aws_security_group" "default" {
 }
 
 locals {
-  elasticache_subnet_group = "${var.elasticache_subnet_group != "" ? var.elasticache_subnet_group : join("", aws_elasticache_subnet_group.default.*.name) }"
+  elasticache_subnet_group_name = "${var.elasticache_subnet_group_name != "" ? var.elasticache_subnet_group_name : join("", aws_elasticache_subnet_group.default.*.name) }"
 }
 
 resource "aws_elasticache_subnet_group" "default" {

--- a/main.tf
+++ b/main.tf
@@ -64,7 +64,7 @@ resource "aws_elasticache_replication_group" "default" {
   parameter_group_name          = "${aws_elasticache_parameter_group.default.name}"
   availability_zones            = ["${slice(var.availability_zones, 0, var.cluster_size)}"]
   automatic_failover_enabled    = "${var.automatic_failover}"
-  subnet_group_name             = "${local.elasticache_subnet_group}"
+  subnet_group_name             = "${local.elasticache_subnet_group_name}"
   security_group_ids            = ["${aws_security_group.default.id}"]
   maintenance_window            = "${var.maintenance_window}"
   notification_topic_arn        = "${var.notification_topic_arn}"

--- a/output.tf
+++ b/output.tf
@@ -1,11 +1,11 @@
 output "id" {
   value       = "${join("", aws_elasticache_replication_group.default.*.id)}"
-  description = "Redis cluster id"
+  description = "Redis cluster ID"
 }
 
 output "security_group_id" {
   value       = "${join("", aws_security_group.default.*.id)}"
-  description = "Security group id"
+  description = "Security group ID"
 }
 
 output "port" {

--- a/variables.tf
+++ b/variables.tf
@@ -35,7 +35,7 @@ variable "subnets" {
   default     = []
 }
 
-variable "elasticache_subnet_group" {
+variable "elasticache_subnet_group_name" {
   type        = "string"
   description = "Subnet group ID for the Elastic cache instance"
   default     = ""

--- a/variables.tf
+++ b/variables.tf
@@ -35,6 +35,12 @@ variable "subnets" {
   default     = []
 }
 
+variable "elasticache_subnet_group" {
+  type        = "string"
+  description = "Subnet group ID for the Elastic cache instance"
+  default     = ""
+}
+
 variable "maintenance_window" {
   default     = "wed:03:00-wed:04:00"
   description = "Maintenance window"

--- a/variables.tf
+++ b/variables.tf
@@ -37,7 +37,7 @@ variable "subnets" {
 
 variable "elasticache_subnet_group_name" {
   type        = "string"
-  description = "Subnet group ID for the Elastic cache instance"
+  description = "Subnet group ID for the ElastiCache instance"
   default     = ""
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -25,19 +25,18 @@ variable "security_groups" {
 }
 
 variable "vpc_id" {
-  default     = "REQUIRED"
   description = "AWS VPC id"
 }
 
 variable "subnets" {
   type        = "list"
-  description = "AWS subnet ids"
+  description = "AWS subnet IDs"
   default     = []
 }
 
 variable "elasticache_subnet_group_name" {
   type        = "string"
-  description = "Subnet group ID for the ElastiCache instance"
+  description = "Subnet group name for the ElastiCache instance"
   default     = ""
 }
 


### PR DESCRIPTION
## what

Add optional variable for the Elasticache subnet group ID so we can 
create the replication group in an already existing subnet group.

## why 

Closes https://github.com/cloudposse/terraform-aws-elasticache-redis/issues/30