### PR TITLE
Enable backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,17 +272,17 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 |---|---|---|---|---|---|
 
   [osterman_homepage]: https://github.com/osterman
-  [osterman_avatar]: https://github.com/osterman.png?size=150
+  [osterman_avatar]: https://img.cloudposse.com/150x150/https://github.com/osterman.png
   [goruha_homepage]: https://github.com/goruha
-  [goruha_avatar]: https://github.com/goruha.png?size=150
+  [goruha_avatar]: https://img.cloudposse.com/150x150/https://github.com/goruha.png
   [aknysh_homepage]: https://github.com/aknysh
-  [aknysh_avatar]: https://github.com/aknysh.png?size=150
+  [aknysh_avatar]: https://img.cloudposse.com/150x150/https://github.com/aknysh.png
   [darend_homepage]: https://github.com/darend
-  [darend_avatar]: https://github.com/darend.png?size=150
+  [darend_avatar]: https://img.cloudposse.com/150x150/https://github.com/darend.png
   [MoonMoon1919_homepage]: https://github.com/MoonMoon1919
-  [MoonMoon1919_avatar]: https://github.com/MoonMoon1919.png?size=150
+  [MoonMoon1919_avatar]: https://img.cloudposse.com/150x150/https://github.com/MoonMoon1919.png
   [christopherriley_homepage]: https://github.com/christopherriley
-  [christopherriley_avatar]: https://github.com/christopherriley.png?size=150
+  [christopherriley_avatar]: https://img.cloudposse.com/150x150/https://github.com/christopherriley.png
 
 
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ Available targets:
 | port | Redis port | number | `6379` | no |
 | replication_group_id | Replication group ID with the following constraints:  A name must contain from 1 to 20 alphanumeric characters or hyphens.   The first character must be a letter.   A name cannot end with a hyphen or contain two consecutive hyphens. | string | `` | no |
 | security_groups | Security Group IDs | list(string) | `<list>` | no |
+| snapshot_retention_limit | The number of days for which ElastiCache will retain automatic cache cluster snapshots before deleting them. | number | `0` | no |
+| snapshot_window | The daily time range (in UTC) during which ElastiCache will begin taking a daily snapshot of your cache cluster. | string | `06:30-07:30` | no |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | string | `` | no |
 | subnets | Subnet IDs | list(string) | `<list>` | no |
 | tags | Additional tags (_e.g._ map("BusinessUnit","ABC") | map(string) | `<map>` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -27,6 +27,8 @@
 | port | Redis port | number | `6379` | no |
 | replication_group_id | Replication group ID with the following constraints:  A name must contain from 1 to 20 alphanumeric characters or hyphens.   The first character must be a letter.   A name cannot end with a hyphen or contain two consecutive hyphens. | string | `` | no |
 | security_groups | Security Group IDs | list(string) | `<list>` | no |
+| snapshot_retention_limit | The number of days for which ElastiCache will retain automatic cache cluster snapshots before deleting them. | number | `0` | no |
+| snapshot_window | The daily time range (in UTC) during which ElastiCache will begin taking a daily snapshot of your cache cluster. | string | `06:30-07:30` | no |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | string | `` | no |
 | subnets | Subnet IDs | list(string) | `<list>` | no |
 | tags | Additional tags (_e.g._ map("BusinessUnit","ABC") | map(string) | `<map>` | no |

--- a/main.tf
+++ b/main.tf
@@ -77,6 +77,8 @@ resource "aws_elasticache_replication_group" "default" {
   engine_version                = var.engine_version
   at_rest_encryption_enabled    = var.at_rest_encryption_enabled
   transit_encryption_enabled    = var.transit_encryption_enabled
+  snapshot_window               = var.snapshot_window
+  snapshot_retention_limit      = var.snapshot_retention_limit
 
   tags = module.label.tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -185,3 +185,15 @@ variable "replication_group_id" {
   description = "Replication group ID with the following constraints: \nA name must contain from 1 to 20 alphanumeric characters or hyphens. \n The first character must be a letter. \n A name cannot end with a hyphen or contain two consecutive hyphens."
   default     = ""
 }
+
+variable "snapshot_window" {
+  type        = string
+  description = "The daily time range (in UTC) during which ElastiCache will begin taking a daily snapshot of your cache cluster."
+  default     = "06:30-07:30"
+}
+
+variable "snapshot_retention_limit" {
+  type        = number
+  description = "The number of days for which ElastiCache will retain automatic cache cluster snapshots before deleting them."
+  default     = 0
+}


### PR DESCRIPTION
Signed-off-by: Salvatore Mazzarino <apocalipse89@gmail.com>

This gives the possibility to create enable automatic backups.

Could I also backport this change to a release before TF 0.12? So codebase that has not been migrated to TF would support this.

Thank you