### PR TITLE
do not specify token when transit_encryption_enabled is set to false

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -61,7 +61,7 @@ resource "aws_elasticache_parameter_group" "default" {
 resource "aws_elasticache_replication_group" "default" {
   count = var.enabled ? 1 : 0
 
-  auth_token                    = transit_encryption_enabled ? var.auth_token : null
+  auth_token                    = var.transit_encryption_enabled ? var.auth_token : null
   replication_group_id          = var.replication_group_id == "" ? module.label.id : var.replication_group_id
   replication_group_description = module.label.id
   node_type                     = var.instance_type

--- a/main.tf
+++ b/main.tf
@@ -61,7 +61,7 @@ resource "aws_elasticache_parameter_group" "default" {
 resource "aws_elasticache_replication_group" "default" {
   count = var.enabled ? 1 : 0
 
-  auth_token                    = var.auth_token
+  auth_token                    = transit_encryption_enabled ? var.auth_token : null
   replication_group_id          = var.replication_group_id == "" ? module.label.id : var.replication_group_id
   replication_group_description = module.label.id
   node_type                     = var.instance_type


### PR DESCRIPTION
Empty auth token is causing issues with redis `3.2.10` as this particular Redis version does not support transit ecryption:

```
Error: "auth_token" must contain from 16 to 128 alphanumeric characters or symbols (excluding @, ", and /)

  on .terraform/modules/redis-<redacted>/main.tf line 61, in resource "aws_elasticache_replication_group" "default":
  61: resource "aws_elasticache_replication_group" "default" {
```