### PR TITLE
restrict elasticache subnet group name to a max of 40 characters

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -58,7 +58,7 @@ locals {
 
 resource "aws_elasticache_subnet_group" "default" {
   count      = var.enabled && var.elasticache_subnet_group_name == "" && length(var.subnets) > 0 ? 1 : 0
-  name       = module.label.id
+  name       = lower(substr(module.label.id, 0, 40))
   subnet_ids = var.subnets
 }
 


### PR DESCRIPTION
If the group name exceeds 40 characters the apply will fail. This will concat the string to be 40 characters or less.