### PR TITLE
Adds dns_subdomain variable to override subdomain

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Available targets:
 | snapshot_retention_limit | The number of days for which ElastiCache will retain automatic cache cluster snapshots before deleting them. | number | `0` | no |
 | snapshot_window | The daily time range (in UTC) during which ElastiCache will begin taking a daily snapshot of your cache cluster. | string | `06:30-07:30` | no |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | string | `` | no |
+| dns_subdomain | The subdomain to use for the CNAME record. If not provided then the CNAME record will use var.name. | string | `` | no |
 | subnets | Subnet IDs | list(string) | `<list>` | no |
 | tags | Additional tags (_e.g._ map("BusinessUnit","ABC") | map(string) | `<map>` | no |
 | transit_encryption_enabled | Enable TLS | bool | `true` | no |

--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Available targets:
 | cluster_mode_replicas_per_node_group | Number of replica nodes in each node group. Valid values are 0 to 5. Changing this number will force a new resource | number | `0` | no |
 | cluster_size | Number of nodes in cluster. *Ignored when `cluster_mode_enabled` == `true`* | number | `1` | no |
 | delimiter | Delimiter between `name`, `namespace`, `stage` and `attributes` | string | `-` | no |
+| dns_subdomain | The subdomain to use for the CNAME record. If not provided then the CNAME record will use var.name. | string | `` | no |
 | elasticache_subnet_group_name | Subnet group name for the ElastiCache instance | string | `` | no |
 | enabled | Set to false to prevent the module from creating any resources | bool | `true` | no |
 | engine_version | Redis engine version | string | `4.0.10` | no |
@@ -201,7 +202,6 @@ Available targets:
 | snapshot_retention_limit | The number of days for which ElastiCache will retain automatic cache cluster snapshots before deleting them. | number | `0` | no |
 | snapshot_window | The daily time range (in UTC) during which ElastiCache will begin taking a daily snapshot of your cache cluster. | string | `06:30-07:30` | no |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | string | `` | no |
-| dns_subdomain | The subdomain to use for the CNAME record. If not provided then the CNAME record will use var.name. | string | `` | no |
 | subnets | Subnet IDs | list(string) | `<list>` | no |
 | tags | Additional tags (_e.g._ map("BusinessUnit","ABC") | map(string) | `<map>` | no |
 | transit_encryption_enabled | Enable TLS | bool | `true` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -18,6 +18,7 @@
 | cluster_mode_replicas_per_node_group | Number of replica nodes in each node group. Valid values are 0 to 5. Changing this number will force a new resource | number | `0` | no |
 | cluster_size | Number of nodes in cluster. *Ignored when `cluster_mode_enabled` == `true`* | number | `1` | no |
 | delimiter | Delimiter between `name`, `namespace`, `stage` and `attributes` | string | `-` | no |
+| dns_subdomain | The subdomain to use for the CNAME record. If not provided then the CNAME record will use var.name. | string | `` | no |
 | elasticache_subnet_group_name | Subnet group name for the ElastiCache instance | string | `` | no |
 | enabled | Set to false to prevent the module from creating any resources | bool | `true` | no |
 | engine_version | Redis engine version | string | `4.0.10` | no |
@@ -35,7 +36,6 @@
 | snapshot_retention_limit | The number of days for which ElastiCache will retain automatic cache cluster snapshots before deleting them. | number | `0` | no |
 | snapshot_window | The daily time range (in UTC) during which ElastiCache will begin taking a daily snapshot of your cache cluster. | string | `06:30-07:30` | no |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | string | `` | no |
-| dns_subdomain | The subdomain to use for the CNAME record. If not provided then the CNAME record will use var.name. | string | `` | no |
 | subnets | Subnet IDs | list(string) | `<list>` | no |
 | tags | Additional tags (_e.g._ map("BusinessUnit","ABC") | map(string) | `<map>` | no |
 | transit_encryption_enabled | Enable TLS | bool | `true` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -35,6 +35,7 @@
 | snapshot_retention_limit | The number of days for which ElastiCache will retain automatic cache cluster snapshots before deleting them. | number | `0` | no |
 | snapshot_window | The daily time range (in UTC) during which ElastiCache will begin taking a daily snapshot of your cache cluster. | string | `06:30-07:30` | no |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | string | `` | no |
+| dns_subdomain | The subdomain to use for the CNAME record. If not provided then the CNAME record will use var.name. | string | `` | no |
 | subnets | Subnet IDs | list(string) | `<list>` | no |
 | tags | Additional tags (_e.g._ map("BusinessUnit","ABC") | map(string) | `<map>` | no |
 | transit_encryption_enabled | Enable TLS | bool | `true` | no |

--- a/main.tf
+++ b/main.tf
@@ -159,7 +159,7 @@ resource "aws_cloudwatch_metric_alarm" "cache_memory" {
 module "dns" {
   source  = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.3.0"
   enabled = var.enabled && var.zone_id != "" ? true : false
-  name    = var.name
+  name    = var.dns_subdomain != "" ? var.dns_subdomain : var.name
   ttl     = 60
   zone_id = var.zone_id
   records = [join("", aws_elasticache_replication_group.default.*.primary_endpoint_address)]

--- a/variables.tf
+++ b/variables.tf
@@ -174,6 +174,12 @@ variable "zone_id" {
   description = "Route53 DNS Zone ID"
 }
 
+variable "dns_subdomain" {
+  type        = string
+  default     = ""
+  description = "The subdomain to use for the CNAME record. If not provided then the CNAME record will use var.name."
+}
+
 variable "delimiter" {
   type        = string
   default     = "-"


### PR DESCRIPTION
# Info 

Similar to https://github.com/cloudposse/terraform-aws-elastic-beanstalk-environment/pull/96, I needed the ability to scope the subdomain of this service to an environment specific resource. 

@aknysh Before you mention it... I ran into issues with your folks `make readme` command... I did run `make readme/deps` but I am getting the below. Any pointers on that?

```
 terraform-aws-elasticache-redis (branch:master*) » make readme                                                                                                                                                         
Package terraform-docs already installed
make: gomplate: No such file or directory
make: *** [readme/build] Error 1
```