### PR TITLE
make cluster-enabled mode a bit more automated

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Available targets:
 | cluster_mode_enabled | Flag to enable/disable creation of a native redis cluster. `automatic_failover_enabled` must be set to `true`. Only 1 `cluster_mode` block is allowed | bool | `false` | no |
 | cluster_mode_num_node_groups | Number of node groups (shards) for this Redis replication group. Changing this number will trigger an online resizing operation before other settings modifications | number | `0` | no |
 | cluster_mode_replicas_per_node_group | Number of replica nodes in each node group. Valid values are 0 to 5. Changing this number will force a new resource | number | `0` | no |
-| cluster_size | Number of nodes in cluster | number | `1` | no |
+| cluster_size | Number of nodes in cluster. *Ignored when `cluster_mode_enabled` == `true`* | number | `1` | no |
 | delimiter | Delimiter between `name`, `namespace`, `stage` and `attributes` | string | `-` | no |
 | elasticache_subnet_group_name | Subnet group name for the ElastiCache instance | string | `` | no |
 | enabled | Set to false to prevent the module from creating any resources | bool | `true` | no |
@@ -288,7 +288,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyright
 
-Copyright © 2017-2019 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2020 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -16,7 +16,7 @@
 | cluster_mode_enabled | Flag to enable/disable creation of a native redis cluster. `automatic_failover_enabled` must be set to `true`. Only 1 `cluster_mode` block is allowed | bool | `false` | no |
 | cluster_mode_num_node_groups | Number of node groups (shards) for this Redis replication group. Changing this number will trigger an online resizing operation before other settings modifications | number | `0` | no |
 | cluster_mode_replicas_per_node_group | Number of replica nodes in each node group. Valid values are 0 to 5. Changing this number will force a new resource | number | `0` | no |
-| cluster_size | Number of nodes in cluster | number | `1` | no |
+| cluster_size | Number of nodes in cluster. *Ignored when `cluster_mode_enabled` == `true`* | number | `1` | no |
 | delimiter | Delimiter between `name`, `namespace`, `stage` and `attributes` | string | `-` | no |
 | elasticache_subnet_group_name | Subnet group name for the ElastiCache instance | string | `` | no |
 | enabled | Set to false to prevent the module from creating any resources | bool | `true` | no |

--- a/main.tf
+++ b/main.tf
@@ -85,7 +85,7 @@ resource "aws_elasticache_replication_group" "default" {
   replication_group_id          = var.replication_group_id == "" ? module.label.id : var.replication_group_id
   replication_group_description = module.label.id
   node_type                     = var.instance_type
-  number_cache_clusters         = var.cluster_size
+  number_cache_clusters         = var.cluster_mode_enabled ? (1 + var.cluster_mode_replicas_per_node_group) * var.cluster_mode_num_node_groups : var.cluster_size
   port                          = var.port
   parameter_group_name          = join("", aws_elasticache_parameter_group.default.*.name)
   availability_zones            = slice(var.availability_zones, 0, var.cluster_size)
@@ -109,6 +109,7 @@ resource "aws_elasticache_replication_group" "default" {
       num_node_groups         = var.cluster_mode_num_node_groups
     }
   }
+
 }
 
 #

--- a/main.tf
+++ b/main.tf
@@ -67,8 +67,10 @@ resource "aws_elasticache_parameter_group" "default" {
   name   = module.label.id
   family = var.family
 
+
+
   dynamic "parameter" {
-    for_each = var.parameter
+    for_each = var.cluster_mode_enabled ? concat([{ "name" = "cluster-enabled" , "value" = "yes" }], var.parameter) : var.parameter
     content {
       name  = parameter.value.name
       value = parameter.value.value

--- a/main.tf
+++ b/main.tf
@@ -164,5 +164,5 @@ module "dns" {
   name    = var.name
   ttl     = 60
   zone_id = var.zone_id
-  records = [join("", aws_elasticache_replication_group.default.*.primary_endpoint_address)]
+  records = var.cluster_mode_enabled ? [join("", aws_elasticache_replication_group.default.*.configuration_endpoint_address)] : [join("", aws_elasticache_replication_group.default.*.primary_endpoint_address)]
 }

--- a/main.tf
+++ b/main.tf
@@ -70,7 +70,7 @@ resource "aws_elasticache_parameter_group" "default" {
 
 
   dynamic "parameter" {
-    for_each = var.cluster_mode_enabled ? concat([{ "name" = "cluster-enabled" , "value" = "yes" }], var.parameter) : var.parameter
+    for_each = var.cluster_mode_enabled ? concat([{ "name" = "cluster-enabled", "value" = "yes" }], var.parameter) : var.parameter
     content {
       name  = parameter.value.name
       value = parameter.value.value

--- a/outputs.tf
+++ b/outputs.tf
@@ -14,7 +14,7 @@ output "port" {
 }
 
 output "endpoint" {
-  value       = join("", aws_elasticache_replication_group.default.*.primary_endpoint_address)
+  value       = var.cluster_mode_enabled ? join("", aws_elasticache_replication_group.default.*.configuration_endpoint_address) : join("", aws_elasticache_replication_group.default.*.primary_endpoint_address)
   description = "Redis primary endpoint"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -71,7 +71,7 @@ variable "maintenance_window" {
 variable "cluster_size" {
   type        = number
   default     = 1
-  description = "Number of nodes in cluster"
+  description = "Number of nodes in cluster. *Ignored when `cluster_mode_enabled` == `true`*"
 }
 
 variable "port" {


### PR DESCRIPTION
This PR adds the following functionality when setting `cluster_mode_enabled` == `true`:
- Automatically set number of nodes in cluster_size, enabling scale-out with a single parameter change. 
- Automatically set the `cluster-enabled` parameter as an override-able default. 

This PR makes the following fixes when setting `cluster_mode_enabled` == `true`:
- correct the endpoint keyname to fix a `null` value error. 