### PR TITLE
Fix apply_immediately

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -99,6 +99,7 @@ resource "aws_elasticache_replication_group" "default" {
   transit_encryption_enabled    = var.transit_encryption_enabled
   snapshot_window               = var.snapshot_window
   snapshot_retention_limit      = var.snapshot_retention_limit
+  apply_immediately             = var.apply_immediately
 
   tags = module.label.tags
 


### PR DESCRIPTION
It was declared as a variable, but wasn't actually set on the
`aws_elasticache_replication_group` resource.

This MR adds it to the resource, so the changes can be applied
immediately