### PR TITLE
Fix input variable name in Readme Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ For automated tests of the complete example using [bats](https://github.com/bats
     cluster_size               = var.cluster_size
     instance_type              = var.instance_type
     apply_immediately          = true
-    automatic_failover         = false
+    automatic_failover_enabled = false
     engine_version             = var.engine_version
     family                     = var.family
     at_rest_encryption_enabled = var.at_rest_encryption_enabled

--- a/README.yaml
+++ b/README.yaml
@@ -92,7 +92,7 @@ usage: |-
       cluster_size               = var.cluster_size
       instance_type              = var.instance_type
       apply_immediately          = true
-      automatic_failover         = false
+      automatic_failover_enabled = false
       engine_version             = var.engine_version
       family                     = var.family
       at_rest_encryption_enabled = var.at_rest_encryption_enabled

--- a/main.tf
+++ b/main.tf
@@ -88,7 +88,7 @@ resource "aws_elasticache_replication_group" "default" {
   number_cache_clusters         = var.cluster_mode_enabled ? null : var.cluster_size
   port                          = var.port
   parameter_group_name          = join("", aws_elasticache_parameter_group.default.*.name)
-  availability_zones            = var.cluster_mode_enabled ? null : slice(var.availability_zones, 0, var.cluster_size)
+  availability_zones            = length(var.availability_zones) == 0 ? null : slice(var.availability_zones, 0, var.cluster_size)
   automatic_failover_enabled    = var.automatic_failover_enabled
   subnet_group_name             = local.elasticache_subnet_group_name
   security_group_ids            = var.use_existing_security_groups ? var.existing_security_groups : [join("", aws_security_group.default.*.id)]


### PR DESCRIPTION
 Change automatic_failover to automatic_failover_enabled in Readme example to align with the actual inputs.

## what
* Update readme to align with actual inputs (automatic_failover_enabled)

## why
* To have the example given in readme in working condition.
