### PR TITLE
Transit encryption enabled default to null

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,12 +206,12 @@ Available targets:
 
 | Name |
 |------|
-| [aws_cloudwatch_metric_alarm](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/cloudwatch_metric_alarm) |
-| [aws_elasticache_parameter_group](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/elasticache_parameter_group) |
-| [aws_elasticache_replication_group](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/elasticache_replication_group) |
-| [aws_elasticache_subnet_group](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/elasticache_subnet_group) |
-| [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/security_group) |
-| [aws_security_group_rule](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/security_group_rule) |
+| [aws_cloudwatch_metric_alarm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) |
+| [aws_elasticache_parameter_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_parameter_group) |
+| [aws_elasticache_replication_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_replication_group) |
+| [aws_elasticache_subnet_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_subnet_group) |
+| [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) |
+| [aws_security_group_rule](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) |
 
 ## Inputs
 
@@ -267,7 +267,7 @@ Available targets:
 | stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | subnets | Subnet IDs | `list(string)` | `[]` | no |
 | tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
-| transit\_encryption\_enabled | Enable TLS | `bool` | `true` | no |
+| transit\_encryption\_enabled | Whether to enable encryption in transit. If this is enabled, use the [following guide](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/in-transit-encryption.html#connect-tls) to access redis | `bool` | `null` | no |
 | use\_existing\_security\_groups | Flag to enable/disable creation of Security Group in the module. Set to `true` to disable Security Group creation and provide a list of existing security Group IDs in `existing_security_groups` to place the cluster into | `bool` | `false` | no |
 | vpc\_id | VPC ID | `string` | n/a | yes |
 | zone\_id | Route53 DNS Zone ID | `string` | `""` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -24,12 +24,12 @@
 
 | Name |
 |------|
-| [aws_cloudwatch_metric_alarm](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/cloudwatch_metric_alarm) |
-| [aws_elasticache_parameter_group](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/elasticache_parameter_group) |
-| [aws_elasticache_replication_group](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/elasticache_replication_group) |
-| [aws_elasticache_subnet_group](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/elasticache_subnet_group) |
-| [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/security_group) |
-| [aws_security_group_rule](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/security_group_rule) |
+| [aws_cloudwatch_metric_alarm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) |
+| [aws_elasticache_parameter_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_parameter_group) |
+| [aws_elasticache_replication_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_replication_group) |
+| [aws_elasticache_subnet_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_subnet_group) |
+| [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) |
+| [aws_security_group_rule](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) |
 
 ## Inputs
 
@@ -85,7 +85,7 @@
 | stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | subnets | Subnet IDs | `list(string)` | `[]` | no |
 | tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
-| transit\_encryption\_enabled | Enable TLS | `bool` | `true` | no |
+| transit\_encryption\_enabled | Whether to enable encryption in transit. If this is enabled, use the [following guide](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/in-transit-encryption.html#connect-tls) to access redis | `bool` | `null` | no |
 | use\_existing\_security\_groups | Flag to enable/disable creation of Security Group in the module. Set to `true` to disable Security Group creation and provide a list of existing security Group IDs in `existing_security_groups` to place the cluster into | `bool` | `false` | no |
 | vpc\_id | VPC ID | `string` | n/a | yes |
 | zone\_id | Route53 DNS Zone ID | `string` | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -95,7 +95,7 @@ resource "aws_elasticache_replication_group" "default" {
   notification_topic_arn        = var.notification_topic_arn
   engine_version                = var.engine_version
   at_rest_encryption_enabled    = var.at_rest_encryption_enabled
-  transit_encryption_enabled    = var.transit_encryption_enabled
+  transit_encryption_enabled    = var.auth_token != null ? coalesce(true, var.transit_encryption_enabled) : var.transit_encryption_enabled
   kms_key_id                    = var.at_rest_encryption_enabled ? var.kms_key_id : null
   snapshot_name                 = var.snapshot_name
   snapshot_arns                 = var.snapshot_arns

--- a/variables.tf
+++ b/variables.tf
@@ -92,8 +92,8 @@ variable "at_rest_encryption_enabled" {
 
 variable "transit_encryption_enabled" {
   type        = bool
-  default     = true
-  description = "Enable TLS"
+  default     = false
+  description = "Whether to enable encryption in transit. If this is enabled, use the [following guide](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/in-transit-encryption.html#connect-tls) to access redis"
 }
 
 variable "notification_topic_arn" {

--- a/variables.tf
+++ b/variables.tf
@@ -92,7 +92,7 @@ variable "at_rest_encryption_enabled" {
 
 variable "transit_encryption_enabled" {
   type        = bool
-  default     = false
+  default     = null
   description = "Whether to enable encryption in transit. If this is enabled, use the [following guide](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/in-transit-encryption.html#connect-tls) to access redis"
 }
 


### PR DESCRIPTION
## what
* default `transit_encryption_enabled` to `null` which is the default on [`elasticache_replication_group`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_replication_group#transit_encryption_enabled) resource

## why
* Using the default parameters I was surprised that I could not instantly connect to redis via `redis-cli -h hostname -p 6379 ping`
* After some investigation, I found that the culprit was the `transit_encryption_enabled` parameter
* I came across this [doc](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/in-transit-encryption.html#connect-tls) which involves using stunnel to appropriately connect

## references
N/A

