### PR TITLE
Add rds security group description

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,10 +2,11 @@
 # Security Group Resources
 #
 resource "aws_security_group" "default" {
-  count  = module.this.enabled && var.use_existing_security_groups == false ? 1 : 0
-  vpc_id = var.vpc_id
-  name   = module.this.id
-  tags   = module.this.tags
+  count       = module.this.enabled && var.use_existing_security_groups == false ? 1 : 0
+  description = "Security group for Elasticache Redis"
+  vpc_id      = var.vpc_id
+  name        = module.this.id
+  tags        = module.this.tags
 }
 
 resource "aws_security_group_rule" "egress" {


### PR DESCRIPTION
## what
* Add rds security group description

## why
* tfsec complains
    ```
    [AWS018][ERROR] Resource 'module.redis:aws_security_group.default' should include a description for auditing purposes.
    ```

## references
* N/A

