### PR TITLE
fix: make the security group description configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ Available targets:
 | port | Redis port | `number` | `6379` | no |
 | regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | replication\_group\_id | Replication group ID with the following constraints: <br>A name must contain from 1 to 20 alphanumeric characters or hyphens. <br> The first character must be a letter. <br> A name cannot end with a hyphen or contain two consecutive hyphens. | `string` | `""` | no |
+| security\_group\_description | The description for the security group. | `string` | `"Security group for Elasticache Redis"` | no |
 | snapshot\_arns | A single-element string list containing an Amazon Resource Name (ARN) of a Redis RDB snapshot file stored in Amazon S3. Example: arn:aws:s3:::my\_bucket/snapshot1.rdb | `list(string)` | `[]` | no |
 | snapshot\_name | The name of a snapshot from which to restore data into the new node group. Changing the snapshot\_name forces a new resource. | `string` | `null` | no |
 | snapshot\_retention\_limit | The number of days for which ElastiCache will retain automatic cache cluster snapshots before deleting them. | `number` | `0` | no |

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ Available targets:
 | port | Redis port | `number` | `6379` | no |
 | regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | replication\_group\_id | Replication group ID with the following constraints: <br>A name must contain from 1 to 20 alphanumeric characters or hyphens. <br> The first character must be a letter. <br> A name cannot end with a hyphen or contain two consecutive hyphens. | `string` | `""` | no |
-| security\_group\_description | The description for the security group. | `string` | `"Security group for Elasticache Redis"` | no |
+| security\_group\_description | The description for the security group. If this is changed, this will cause a create/destroy on the security group resource. Set this to `null` to maintain parity with releases <= `0.34.0`. | `string` | `"Security group for Elasticache Redis"` | no |
 | snapshot\_arns | A single-element string list containing an Amazon Resource Name (ARN) of a Redis RDB snapshot file stored in Amazon S3. Example: arn:aws:s3:::my\_bucket/snapshot1.rdb | `list(string)` | `[]` | no |
 | snapshot\_name | The name of a snapshot from which to restore data into the new node group. Changing the snapshot\_name forces a new resource. | `string` | `null` | no |
 | snapshot\_retention\_limit | The number of days for which ElastiCache will retain automatic cache cluster snapshots before deleting them. | `number` | `0` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -78,7 +78,7 @@
 | port | Redis port | `number` | `6379` | no |
 | regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | replication\_group\_id | Replication group ID with the following constraints: <br>A name must contain from 1 to 20 alphanumeric characters or hyphens. <br> The first character must be a letter. <br> A name cannot end with a hyphen or contain two consecutive hyphens. | `string` | `""` | no |
-| security\_group\_description | The description for the security group. | `string` | `"Security group for Elasticache Redis"` | no |
+| security\_group\_description | The description for the security group. If this is changed, this will cause a create/destroy on the security group resource. Set this to `null` to maintain parity with releases <= `0.34.0`. | `string` | `"Security group for Elasticache Redis"` | no |
 | snapshot\_arns | A single-element string list containing an Amazon Resource Name (ARN) of a Redis RDB snapshot file stored in Amazon S3. Example: arn:aws:s3:::my\_bucket/snapshot1.rdb | `list(string)` | `[]` | no |
 | snapshot\_name | The name of a snapshot from which to restore data into the new node group. Changing the snapshot\_name forces a new resource. | `string` | `null` | no |
 | snapshot\_retention\_limit | The number of days for which ElastiCache will retain automatic cache cluster snapshots before deleting them. | `number` | `0` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -78,6 +78,7 @@
 | port | Redis port | `number` | `6379` | no |
 | regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | replication\_group\_id | Replication group ID with the following constraints: <br>A name must contain from 1 to 20 alphanumeric characters or hyphens. <br> The first character must be a letter. <br> A name cannot end with a hyphen or contain two consecutive hyphens. | `string` | `""` | no |
+| security\_group\_description | The description for the security group. | `string` | `"Security group for Elasticache Redis"` | no |
 | snapshot\_arns | A single-element string list containing an Amazon Resource Name (ARN) of a Redis RDB snapshot file stored in Amazon S3. Example: arn:aws:s3:::my\_bucket/snapshot1.rdb | `list(string)` | `[]` | no |
 | snapshot\_name | The name of a snapshot from which to restore data into the new node group. Changing the snapshot\_name forces a new resource. | `string` | `null` | no |
 | snapshot\_retention\_limit | The number of days for which ElastiCache will retain automatic cache cluster snapshots before deleting them. | `number` | `0` | no |

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@
 #
 resource "aws_security_group" "default" {
   count       = module.this.enabled && var.use_existing_security_groups == false ? 1 : 0
-  description = "Security group for Elasticache Redis"
+  description = var.security_group_description
   vpc_id      = var.vpc_id
   name        = module.this.id
   tags        = module.this.tags

--- a/variables.tf
+++ b/variables.tf
@@ -18,7 +18,7 @@ variable "allowed_security_groups" {
 
 variable "security_group_description" {
   type        = string
-  description = "The description for the security group."
+  description = "The description for the security group. If this is changed, this will cause a create/destroy on the security group resource. Set this to `null` to maintain parity with releases <= `0.34.0`."
   default     = "Security group for Elasticache Redis"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -16,6 +16,12 @@ variable "allowed_security_groups" {
   description = "List of Security Group IDs that are allowed ingress to the cluster's Security Group created in the module"
 }
 
+variable "security_group_description" {
+  type        = string
+  description = "The description for the security group."
+  default     = "Security group for Elasticache Redis"
+}
+
 variable "allowed_cidr_blocks" {
   type        = list(string)
   default     = []


### PR DESCRIPTION
## what
* Made the security group description configurable

## why
* Since [v0.35.0](https://github.com/cloudposse/terraform-aws-elasticache-redis/releases/tag/0.35.0) a description will be set which replaces the default "Managed by Terraform". Unfortunately, a change in security group description requires it to be deleted and re-created. This is however not possible when the security group is in active use and result in a state apply failure. This variable can be used to retain the existing "Managed by Terraform" description which doesn't trigger a re-create of the security group.

## references
* #114