### PR TITLE
Security group replacement fix

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -5,8 +5,12 @@ resource "aws_security_group" "default" {
   count       = module.this.enabled && var.use_existing_security_groups == false ? 1 : 0
   description = var.security_group_description
   vpc_id      = var.vpc_id
-  name        = module.this.id
+  name_prefix = "${module.this.id}${module.this.delimeter}"
   tags        = module.this.tags
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group_rule" "egress" {

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ resource "aws_security_group" "default" {
   count       = module.this.enabled && var.use_existing_security_groups == false ? 1 : 0
   description = var.security_group_description
   vpc_id      = var.vpc_id
-  name_prefix = "${module.this.id}${module.this.delimeter}"
+  name_prefix = "${module.this.id}${module.this.delimiter}"
   tags        = module.this.tags
 
   lifecycle {


### PR DESCRIPTION
## what
* Add `create_before_destroy = true` lifecycle rule to default security group
* Use `name-prefix` instead of `name` for default security group

## why
I made upgrade from tag `0.25.0` to `0.37.0`. In one of the versions you have changed default description from `Managed by Terraform` to `Security group for Elasticache Redis`. This change is forcing replacement as you can see below.
```
  # module.redis.aws_security_group.default[0] must be replaced
-/+ resource "aws_security_group" "default" {
      ~ arn                    = "arn:aws:ec2:eu-west-1:XXXXXXXXXX:security-group/WWWWWWWWWW" -> (known after apply)
      ~ description            = "Managed by Terraform" -> "Security group for Elasticache Redis" # forces replacement
      ~ egress                 = [
          - {
              - cidr_blocks      = [
                  - "0.0.0.0/0",
                ]
              - description      = "Allow all egress traffic"
              - from_port        = 0
              - ipv6_cidr_blocks = []
              - prefix_list_ids  = []
              - protocol         = "-1"
              - security_groups  = []
              - self             = false
              - to_port          = 0
            },
        ] -> (known after apply)
      ~ id                     = "WWWWWWWWWW" -> (known after apply)
      ~ ingress                = [
          - {
              - cidr_blocks      = []
              - description      = "Allow inbound traffic from existing Security Groups"
              - from_port        = 6379
              - ipv6_cidr_blocks = []
              - prefix_list_ids  = []
              - protocol         = "tcp"
              - security_groups  = [
                  - "ZZZZZZZZZZ",
                ]
              - self             = false
              - to_port          = 6379
            },
        ] -> (known after apply)
        name                   = "YYYYYYYYY"
      + name_prefix            = (known after apply)
      ~ owner_id               = "XXXXXXXXXX" -> (known after apply)
        tags                   = {}
        # (2 unchanged attributes hidden)
    }
```
After apply terraform is not able to remove old security group because redis cluster is still using it.
```
module.redis.aws_security_group.default[0]: Still destroying... [id=WWWWWWWWWW, 50s elapsed]
...
module.redis.aws_security_group.default[0]: Still destroying... [id=WWWWWWWWWW, 10m0s elapsed]

Error: Error deleting security group: DependencyViolation: resource WWWWWWWWWW has a dependent object
	status code: 400, request id: 018d6816-daed-425c-a59e-a9d0a5f69f6b
```
This PR is fixing this issue. `create_before_destroy` rule will always create new security group before removing old one. With `name_prefix` we will be sure that new security group will not have duplicated name which could also cause errors.

## references
* closes #86 

