### PR TITLE
Chore: bumps security group module version to 0.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Available targets:
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_dns"></a> [dns](#module\_dns) | cloudposse/route53-cluster-hostname/aws | 0.12.2 |
-| <a name="module_security_group"></a> [security\_group](#module\_security\_group) | cloudposse/security-group/aws | 0.3.1 |
+| <a name="module_security_group"></a> [security\_group](#module\_security\_group) | cloudposse/security-group/aws | 0.4.1 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 
 ## Resources

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -18,7 +18,7 @@
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_dns"></a> [dns](#module\_dns) | cloudposse/route53-cluster-hostname/aws | 0.12.2 |
-| <a name="module_security_group"></a> [security\_group](#module\_security\_group) | cloudposse/security-group/aws | 0.3.1 |
+| <a name="module_security_group"></a> [security\_group](#module\_security\_group) | cloudposse/security-group/aws | 0.4.1 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 
 ## Resources

--- a/main.tf
+++ b/main.tf
@@ -18,8 +18,8 @@ module "security_group" {
   source  = "cloudposse/security-group/aws"
   version = "0.4.1"
 
-  rules           = var.security_group_rules
-  vpc_id          = var.vpc_id
+  rules  = var.security_group_rules
+  vpc_id = var.vpc_id
 
   enabled = local.security_group_enabled
   context = module.this.context


### PR DESCRIPTION
## what

* Bumps security group module version to 0.4.1

## why

* Incorporate changes related to tenants
* Keeping up to date

## references
