### PR TITLE
Default "zone_id" to empty string for "dns" module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -196,7 +196,7 @@ module "dns" {
   enabled  = module.this.enabled && length(var.zone_id) > 0 ? true : false
   dns_name = var.dns_subdomain != "" ? var.dns_subdomain : module.this.id
   ttl      = 60
-  zone_id  = try(var.zone_id[0], var.zone_id)
+  zone_id  = try(var.zone_id[0], "")
   records  = var.cluster_mode_enabled ? [join("", aws_elasticache_replication_group.default.*.configuration_endpoint_address)] : [join("", aws_elasticache_replication_group.default.*.primary_endpoint_address)]
 
   context = module.this.context


### PR DESCRIPTION
## what
* `zone_id` passed to `dns` module must be a string

## why
* `dns` module expects `zone_id` to be type string
* If `var.zone_id[0]` try function call fails it defaults to `[]`, which terraform complains about:
```
│ Error: Invalid value for module argument
│ 
│   on .terraform/modules/[REDACTED]/main.tf line 199, in module "dns":
│  199:   zone_id  = try(var.zone_id[0], var.zone_id)
│ 
│ The given value is not suitable for child module variable "zone_id" defined at .terraform/modules/[REDACTED].dns/variables.tf:1,1-19: string required.
```

I am unsure why it doesn't simply skip this check because of `length(var.zone_id) > 0` (which is `[]`). :thinking: 

My current workaround is setting `zone_id = ""` in the module resource.

## references
* #133