### PR TITLE
Update outputs.tf

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -24,7 +24,7 @@ output "endpoint" {
 }
 
 output "reader_endpoint_address" {
-  value       = join("", aws_elasticache_replication_group.default.*.reader_endpoint_address)
+  value       = var.cluster_mode_enabled ? null : join("", aws_elasticache_replication_group.default.*.reader_endpoint_address)
   description = "The address of the endpoint for the reader node in the replication group, if the cluster mode is disabled."
 }
 


### PR DESCRIPTION
Update reader_endpoint_address  to null when cluster_mode_enabled true.

## what
Update reader_endpoint_address to null when cluster_mode_enabled is enabled.



## why

- Update reader_endpoint_address to null when cluster_mode_enabled is enabled and cluster_mode_num_node_groups == 1  otherwise after the creation  creation the terraform return an error of null variable.



## references

- Closes #137 
