### PR TITLE
added description on resources aws_elasticache_subnet_group and aws_e…

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -82,15 +82,17 @@ locals {
 }
 
 resource "aws_elasticache_subnet_group" "default" {
-  count      = module.this.enabled && var.elasticache_subnet_group_name == "" && length(var.subnets) > 0 ? 1 : 0
-  name       = module.this.id
-  subnet_ids = var.subnets
+  count       = module.this.enabled && var.elasticache_subnet_group_name == "" && length(var.subnets) > 0 ? 1 : 0
+  name        = module.this.id
+  description = "Elasticache subnet group for ${module.this.id}"
+  subnet_ids  = var.subnets
 }
 
 resource "aws_elasticache_parameter_group" "default" {
-  count  = module.this.enabled ? 1 : 0
-  name   = module.this.id
-  family = var.family
+  count       = module.this.enabled ? 1 : 0
+  name        = module.this.id
+  description = "Elasticache parameter group for ${module.this.id}"
+  family      = var.family
 
   dynamic "parameter" {
     for_each = var.cluster_mode_enabled ? concat([{ name = "cluster-enabled", value = "yes" }], var.parameter) : var.parameter


### PR DESCRIPTION
## what
* Added description for cache subnet group. Otherwise The default is "Managed by Terraform"
* added description of ElastiCache parameter group. Otherwise The default is "Managed by Terraform"

## why
 It may be useful to provide a description of the resource: aws_elasticache_subnet_group and aws_elasticache_parameter_group:
* If we have multiple elasticache-redis clusters in the account.
* Business needs.
* Descrivere utilizzo di quella risorsa

## references
* aws_elasticache_subnet_group: [Doc-Terraform](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_subnet_group)
* aws_elasticache_parameter_group: [Doc-Terraform](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_parameter_group)

