### PR TITLE
Small fixes - convert param values to string, set auto failover to true if cluster enabled

### DIFF
--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -47,7 +47,7 @@ template: |
 
 replacers:
 # Remove irrelevant information from Renovate bot
-- search: '/(?<=---\s+)+^#.*(Renovate configuration|Configuration)(?:.|\n)*?This PR has been generated .*/gm'
+- search: '/(?<=---\s)\s*^#.*(Renovate configuration|Configuration)(?:.|\n)*?This PR has been generated .*/gm'
   replace: ''
 # Remove Renovate bot banner image
 - search: '/\[!\[[^\]]*Renovate\][^\]]*\](\([^)]*\))?\s*\n+/gm'

--- a/main.tf
+++ b/main.tf
@@ -96,7 +96,7 @@ resource "aws_elasticache_parameter_group" "default" {
     for_each = var.cluster_mode_enabled ? concat([{ name = "cluster-enabled", value = "yes" }], var.parameter) : var.parameter
     content {
       name  = parameter.value.name
-      value = parameter.value.value
+      value = tostring(parameter.value.value)
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -112,7 +112,7 @@ resource "aws_elasticache_replication_group" "default" {
   port                          = var.port
   parameter_group_name          = join("", aws_elasticache_parameter_group.default.*.name)
   availability_zones            = length(var.availability_zones) == 0 ? null : [for n in range(0, var.cluster_size) : element(var.availability_zones, n)]
-  automatic_failover_enabled    = var.automatic_failover_enabled
+  automatic_failover_enabled    = var.cluster_mode_enabled ? true : var.automatic_failover_enabled
   multi_az_enabled              = var.multi_az_enabled
   subnet_group_name             = local.elasticache_subnet_group_name
   # It would be nice to remove null or duplicate security group IDs, if there are any, using `compact`,


### PR DESCRIPTION
## what
* Small fixes
* Convert param values to string
* Set auto failover to true if cluster enabled
* Add descriptions to subnet and param groups

## why
* Param values will fail if they are not strings

    ```
    InvalidParameterValue: invalid parameter value, allowed values are:yes,no
    ```

* Auto failover needs to be set to true if cluster mode is enabled or it will fail with an error
    
    ```
    InvalidParameterValue: Redis with cluster mode enabled cannot be created with auto failover turned off.
    ```

## references
* Thanks to @simoferr98 this closes https://github.com/cloudposse/terraform-aws-elasticache-redis/pull/140 

