### PR TITLE
Re-adding tag propagation for cloudwatch alarms

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -101,6 +101,9 @@ resource "aws_elasticache_parameter_group" "default" {
     }
   }
 
+
+  tags = module.this.tags
+
   # Ignore changes to the description since it will try to recreate the resource
   lifecycle {
     ignore_changes = [

--- a/main.tf
+++ b/main.tf
@@ -174,6 +174,8 @@ resource "aws_cloudwatch_metric_alarm" "cache_cpu" {
   alarm_actions = var.alarm_actions
   ok_actions    = var.ok_actions
   depends_on    = [aws_elasticache_replication_group.default]
+
+  tags = module.this.tags
 }
 
 resource "aws_cloudwatch_metric_alarm" "cache_memory" {
@@ -196,6 +198,8 @@ resource "aws_cloudwatch_metric_alarm" "cache_memory" {
   alarm_actions = var.alarm_actions
   ok_actions    = var.ok_actions
   depends_on    = [aws_elasticache_replication_group.default]
+
+  tags = module.this.tags
 }
 
 module "dns" {


### PR DESCRIPTION
## what
In #7, the tag propagation was removed for CloudWatch metric alarms because the tags property did not exist at that time.  This PR adds them back.

## why
* Terraform has had the capability to manage tags for aws_cloudwatch_metric_alarm resources for a while now, so I think we should add it back, as I think it makes sense for tags to propagate to all possible resources managed by the module.
* This also helps me to comply with my organization's tagging policies without the hassle of manual intervention.

## references
* PR where the tags were removed: #7 
* Terraform docs showing tags as a valid option for metric alarms: [aws_cloudwatch_metric_alarm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm#tags)
* Closes https://github.com/cloudposse/terraform-aws-elasticache-redis/pull/148

