### PR TITLE
Fix deprecation warnings

### DIFF
--- a/.github/workflows/auto-context.yml
+++ b/.github/workflows/auto-context.yml
@@ -35,7 +35,7 @@ jobs:
 
     - name: Create Pull Request
       if: steps.update.outputs.create_pull_request == 'true'
-      uses: cloudposse/actions/github/create-pull-request@0.22.0
+      uses: cloudposse/actions/github/create-pull-request@0.30.0
       with:
         token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
         committer: 'cloudpossebot <11232728+cloudpossebot@users.noreply.github.com>'

--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -62,7 +62,7 @@ jobs:
         fi
 
     - name: Auto Test
-      uses: cloudposse/actions/github/repository-dispatch@0.22.0
+      uses: cloudposse/actions/github/repository-dispatch@0.30.0
       # match users by ID because logins (user names) are inconsistent,
       # for example in the REST API Renovate Bot is `renovate[bot]` but
       # in GraphQL it is just `renovate`, plus there is a non-bot

--- a/.github/workflows/auto-readme.yml
+++ b/.github/workflows/auto-readme.yml
@@ -1,0 +1,71 @@
+name: "auto-readme"
+on:
+  workflow_dispatch:
+
+  schedule:
+  # Example of job definition:
+  # .---------------- minute (0 - 59)
+  # |  .------------- hour (0 - 23)
+  # |  |  .---------- day of month (1 - 31)
+  # |  |  |  .------- month (1 - 12) OR jan,feb,mar,apr ...
+  # |  |  |  |  .---- day of week (0 - 6) (Sunday=0 or 7) OR sun,mon,tue,wed,thu,fri,sat
+  # |  |  |  |  |
+  # *  *  *  *  * user-name command to be executed
+
+  # Update README.md nightly at 4am UTC
+  - cron:  '0 4 * * *'
+
+jobs:
+  update:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Find default branch name
+      id: defaultBranch
+      shell: bash
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      run: |
+        default_branch=$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)
+        printf "::set-output name=defaultBranch::%s\n" "${default_branch}"
+        printf "defaultBranchRef.name=%s\n" "${default_branch}"
+
+    - name: Update readme
+      shell: bash
+      id: update
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        DEF: "${{ steps.defaultBranch.outputs.defaultBranch }}"
+      run: |
+        make init
+        make readme/build
+        # Ignore changes if they are only whitespace
+        if ! git diff --quiet README.md && git diff --ignore-all-space --ignore-blank-lines --quiet README.md; then
+          git restore README.md
+          echo Ignoring whitespace-only changes in README
+        fi
+
+    - name: Create Pull Request
+      # This action will not create or change a pull request if there are no changes to make.
+      # If a PR of the auto-update/readme branch is open, this action will just update it, not create a new PR.
+      uses: cloudposse/actions/github/create-pull-request@0.30.0
+      with:
+        token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+        commit-message: Update README.md and docs
+        title: Update README.md and docs
+        body: |-
+          ## what
+          This is an auto-generated PR that updates the README.md and docs
+
+          ## why
+          To have most recent changes of README.md and doc from origin templates
+
+        branch: auto-update/readme
+        base: ${{ steps.defaultBranch.outputs.defaultBranch }}
+        delete-branch: true
+        labels: |
+          auto-update
+          no-release
+          readme

--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: "Handle common commands"
-        uses: cloudposse/actions/github/slash-command-dispatch@0.22.0
+        uses: cloudposse/actions/github/slash-command-dispatch@0.30.0
         with:
           token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
           reaction-token: ${{ secrets.GITHUB_TOKEN }}
@@ -24,7 +24,7 @@ jobs:
       - name: "Checkout commit"
         uses: actions/checkout@v2
       - name: "Run tests"
-        uses: cloudposse/actions/github/slash-command-dispatch@0.22.0
+        uses: cloudposse/actions/github/slash-command-dispatch@0.30.0
         with:
           token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
           reaction-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - name: "Checkout source code at current commit"
       uses: actions/checkout@v2
-    - uses: mszostok/codeowners-validator@v0.5.0
+    - uses: mszostok/codeowners-validator@v0.7.1
       if: github.event.pull_request.head.repo.full_name == github.repository
       name: "Full check of CODEOWNERS"
       with:
@@ -18,10 +18,12 @@ jobs:
         # files so we can use the same CODEOWNERS file for Terraform and non-Terraform repos
         #   checks: "files,syntax,owners,duppatterns"
         checks: "syntax,owners,duppatterns"
+        owner_checker_allow_unowned_patterns: "false"
         # GitHub access token is required only if the `owners` check is enabled
         github_access_token: "${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}"
-    - uses: mszostok/codeowners-validator@v0.5.0
+    - uses: mszostok/codeowners-validator@v0.7.1
       if: github.event.pull_request.head.repo.full_name != github.repository
       name: "Syntax check of CODEOWNERS"
       with:
         checks: "syntax,duppatterns"
+        owner_checker_allow_unowned_patterns: "false"

--- a/main.tf
+++ b/main.tf
@@ -118,9 +118,9 @@ resource "aws_elasticache_replication_group" "default" {
 
   auth_token                    = var.transit_encryption_enabled ? var.auth_token : null
   replication_group_id          = var.replication_group_id == "" ? module.this.id : var.replication_group_id
-  replication_group_description = module.this.id
+  description                   = module.this.id
   node_type                     = var.instance_type
-  number_cache_clusters         = var.cluster_mode_enabled ? null : var.cluster_size
+  num_cache_clusters            = var.cluster_mode_enabled ? null : var.cluster_size
   port                          = var.port
   parameter_group_name          = join("", aws_elasticache_parameter_group.default.*.name)
   availability_zones            = length(var.availability_zones) == 0 ? null : [for n in range(0, var.cluster_size) : element(var.availability_zones, n)]
@@ -146,13 +146,8 @@ resource "aws_elasticache_replication_group" "default" {
 
   tags = module.this.tags
 
-  dynamic "cluster_mode" {
-    for_each = var.cluster_mode_enabled ? ["true"] : []
-    content {
-      replicas_per_node_group = var.cluster_mode_replicas_per_node_group
-      num_node_groups         = var.cluster_mode_num_node_groups
-    }
-  }
+  num_node_groups            = var.cluster_mode_enabled ? var.cluster_mode_num_node_groups : null
+  replicas_per_node_group    = var.cluster_mode_enabled ? var.cluster_mode_replicas_per_node_group : null
 }
 
 #

--- a/main.tf
+++ b/main.tf
@@ -116,17 +116,17 @@ resource "aws_elasticache_parameter_group" "default" {
 resource "aws_elasticache_replication_group" "default" {
   count = module.this.enabled ? 1 : 0
 
-  auth_token                    = var.transit_encryption_enabled ? var.auth_token : null
-  replication_group_id          = var.replication_group_id == "" ? module.this.id : var.replication_group_id
-  description                   = module.this.id
-  node_type                     = var.instance_type
-  num_cache_clusters            = var.cluster_mode_enabled ? null : var.cluster_size
-  port                          = var.port
-  parameter_group_name          = join("", aws_elasticache_parameter_group.default.*.name)
-  availability_zones            = length(var.availability_zones) == 0 ? null : [for n in range(0, var.cluster_size) : element(var.availability_zones, n)]
-  automatic_failover_enabled    = var.cluster_mode_enabled ? true : var.automatic_failover_enabled
-  multi_az_enabled              = var.multi_az_enabled
-  subnet_group_name             = local.elasticache_subnet_group_name
+  auth_token                 = var.transit_encryption_enabled ? var.auth_token : null
+  replication_group_id       = var.replication_group_id == "" ? module.this.id : var.replication_group_id
+  description                = module.this.id
+  node_type                  = var.instance_type
+  num_cache_clusters         = var.cluster_mode_enabled ? null : var.cluster_size
+  port                       = var.port
+  parameter_group_name       = join("", aws_elasticache_parameter_group.default.*.name)
+  availability_zones         = length(var.availability_zones) == 0 ? null : [for n in range(0, var.cluster_size) : element(var.availability_zones, n)]
+  automatic_failover_enabled = var.cluster_mode_enabled ? true : var.automatic_failover_enabled
+  multi_az_enabled           = var.multi_az_enabled
+  subnet_group_name          = local.elasticache_subnet_group_name
   # It would be nice to remove null or duplicate security group IDs, if there are any, using `compact`,
   # but that causes problems, and having duplicates does not seem to cause problems.
   # See https://github.com/hashicorp/terraform/issues/29799
@@ -146,8 +146,8 @@ resource "aws_elasticache_replication_group" "default" {
 
   tags = module.this.tags
 
-  num_node_groups            = var.cluster_mode_enabled ? var.cluster_mode_num_node_groups : null
-  replicas_per_node_group    = var.cluster_mode_enabled ? var.cluster_mode_replicas_per_node_group : null
+  num_node_groups         = var.cluster_mode_enabled ? var.cluster_mode_num_node_groups : null
+  replicas_per_node_group = var.cluster_mode_enabled ? var.cluster_mode_replicas_per_node_group : null
 }
 
 #


### PR DESCRIPTION
## what
* Replaces use of deprecated attributes (`cluster_mode`, `replication_group_description`, `number_cache_clusters`) in `aws_elasticache_replication_group` resurce when using provider registry.terraform.io/hashicorp/aws v4.12.0

## why
Eliminate warnings when running `terraform plan` by moving to latest supported attributes instead.

## references

#### Terraform aws provider docs
* [cluster_mode block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_replication_group#cluster_mode)
* [number_cache_clusters](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_replication_group#number_cache_clusters)
* [replication_group_description](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_replication_group#replication_group_description)


* See my [comment](https://github.com/cloudposse/terraform-aws-elasticache-redis/issues/155#issuecomment-1113122373) on #155 
closes #155

