### PR TITLE
use terraform-aws-provider 4x for num_cache_clusters

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.26"
+      version = ">= 4.15"
     }
   }
 }


### PR DESCRIPTION



## what
* Update minimum version of terraform aws provider to support num_cache_clusters


## why
* fix for https://github.com/cloudposse/terraform-aws-elasticache-redis/pull/160#issuecomment-1135556367


