### PR TITLE
feat: Add support for aws provider 5.0

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -10,6 +10,7 @@ on:
       - 'docs/**'
       - 'examples/**'
       - 'test/**'
+      - 'README.*'
 
 permissions:
   contents: write

--- a/main.tf
+++ b/main.tf
@@ -115,17 +115,17 @@ resource "aws_elasticache_parameter_group" "default" {
 resource "aws_elasticache_replication_group" "default" {
   count = module.this.enabled ? 1 : 0
 
-  auth_token                 = var.transit_encryption_enabled ? var.auth_token : null
-  replication_group_id       = var.replication_group_id == "" ? module.this.id : var.replication_group_id
-  description                = coalesce(var.description, module.this.id)
-  node_type                  = var.instance_type
-  num_cache_clusters         = var.cluster_mode_enabled ? null : var.cluster_size
-  port                       = var.port
-  parameter_group_name       = join("", aws_elasticache_parameter_group.default[*].name)
-  availability_zones         = length(var.availability_zones) == 0 ? null : [for n in range(0, var.cluster_size) : element(var.availability_zones, n)]
-  automatic_failover_enabled = var.cluster_mode_enabled ? true : var.automatic_failover_enabled
-  multi_az_enabled           = var.multi_az_enabled
-  subnet_group_name          = local.elasticache_subnet_group_name
+  auth_token                  = var.transit_encryption_enabled ? var.auth_token : null
+  replication_group_id        = var.replication_group_id == "" ? module.this.id : var.replication_group_id
+  description                 = coalesce(var.description, module.this.id)
+  node_type                   = var.instance_type
+  num_cache_clusters          = var.cluster_mode_enabled ? null : var.cluster_size
+  port                        = var.port
+  parameter_group_name        = join("", aws_elasticache_parameter_group.default[*].name)
+  preferred_cache_cluster_azs = length(var.availability_zones) == 0 ? null : [for n in range(0, var.cluster_size) : element(var.availability_zones, n)]
+  automatic_failover_enabled  = var.cluster_mode_enabled ? true : var.automatic_failover_enabled
+  multi_az_enabled            = var.multi_az_enabled
+  subnet_group_name           = local.elasticache_subnet_group_name
   # It would be nice to remove null or duplicate security group IDs, if there are any, using `compact`,
   # but that causes problems, and having duplicates does not seem to cause problems.
   # See https://github.com/hashicorp/terraform/issues/29799


### PR DESCRIPTION
## why

That field was deprecated in 4.0 and was removed in 5.0

Note:

```
make init
make github/init
make readme
```

Already runed and committed