### PR TITLE
add cbd functionality to cache parameter group

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -254,3 +254,12 @@ variable "auto_minor_version_upgrade" {
   default     = null
   description = "Specifies whether minor version engine upgrades will be applied automatically to the underlying Cache Cluster instances during the maintenance window. Only supported if the engine version is 6 or higher."
 }
+
+variable "parameter_group_create_before_destroy" {
+  type        = bool
+  description = <<-EOT
+    Set `true` to enable terraform `create_before_destroy` behavior on the created parameter group.
+    Note that changing this value will cause the parameter group to be replaced.
+    EOT
+  default     = true
+}

--- a/versions.tf
+++ b/versions.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 4.18"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
   }
 }


### PR DESCRIPTION
## what

- This PR gives you the option to generate the Elasticache Parameter Group using a create before destroy lifecycle 

## why

- When you try to upgrade/change the engine version of the instance you're required to change the family of the parameter group to match the engine version. The terraform apply fails because the name of the parameter group is the same and is still in use.

<img width="1142" alt="image" src="https://github.com/cloudposse/terraform-aws-elasticache-redis/assets/43350900/92e81387-36dd-447c-a6c4-2eb7c1a6ac53">
