### PR TITLE
feat: Allow configuring auth_token_update_strategy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,8 @@
 .idea
 *.iml
 
+# Locks
+.terraform.lock.hcl
+
 **/.build-harness
 **/build-harness

--- a/main.tf
+++ b/main.tf
@@ -136,6 +136,7 @@ resource "aws_elasticache_replication_group" "default" {
   count = local.enabled ? 1 : 0
 
   auth_token                  = var.transit_encryption_enabled ? var.auth_token : null
+  auth_token_update_strategy  = var.auth_token_update_strategy
   replication_group_id        = var.replication_group_id == "" ? module.this.id : var.replication_group_id
   description                 = coalesce(var.description, module.this.id)
   node_type                   = var.instance_type

--- a/variables.tf
+++ b/variables.tf
@@ -158,6 +158,17 @@ variable "auth_token" {
   default     = null
 }
 
+variable "auth_token_update_strategy" {
+  type        = string
+  description = "Strategy to use when updating the auth_token. Valid values are `SET`, `ROTATE`, and `DELETE`. Defaults to `ROTATE`."
+  default     = "ROTATE"
+
+  validation {
+    condition     = contains(["set", "rotate", "delete"], lower(var.auth_token_update_strategy))
+    error_message = "Valid values for auth_token_update_strategy are `SET`, `ROTATE`, and `DELETE`."
+  }
+}
+
 variable "kms_key_id" {
   type        = string
   description = "The ARN of the key that you wish to use if encrypting at rest. If not supplied, uses service managed encryption. `at_rest_encryption_enabled` must be set to `true`"

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.18"
+      version = ">= 5.27.0"
     }
   }
 }


### PR DESCRIPTION
## what

Allow configuring `auth_token_update_strategy` provider setting.

This has been added to [AWS Provider on v5.27.0](https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#5270-november-27-2023) in this PR https://github.com/hashicorp/terraform-provider-aws/pull/16203

## why

Give user the flexibility to change the update strategy when setting/changing the `auth_token`.

## references

Closes #55 
