### PR TITLE
248 - Fix planning failure

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -115,13 +115,13 @@ locals {
   endpoint_cluster    = try(aws_elasticache_replication_group.default[0].configuration_endpoint_address, null)
   endpoint_instance   = try(aws_elasticache_replication_group.default[0].primary_endpoint_address, null)
   # Use the serverless endpoint if serverless mode is enabled, otherwise use the cluster endpoint, otherwise use the instance endpoint
-  endpoint_address = coalesce(local.endpoint_serverless, local.endpoint_cluster, local.endpoint_instance)
+  endpoint_address = local.enabled ? coalesce(local.endpoint_serverless, local.endpoint_cluster, local.endpoint_instance) : null
 
   reader_endpoint_serverless = try(aws_elasticache_serverless_cache.default[0].reader_endpoint[0].address, null)
   reader_endpoint_cluster    = try(aws_elasticache_replication_group.default[0].reader_endpoint_address, null)
   reader_endpoint_instance   = try(aws_elasticache_replication_group.default[0].reader_endpoint_address, null)
   # Use the serverless reader endpoint if serverless mode is enabled, otherwise use the cluster reader endpoint, otherwise use the instance reader endpoint, otherwise use the endpoint address
-  reader_endpoint_address = coalesce(local.reader_endpoint_serverless, local.reader_endpoint_cluster, local.reader_endpoint_instance, local.endpoint_address)
+  reader_endpoint_address = local.enabled ? coalesce(local.reader_endpoint_serverless, local.reader_endpoint_cluster, local.reader_endpoint_instance, local.endpoint_address) : null
 }
 
 resource "aws_elasticache_subnet_group" "default" {


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
- `terraform plan` does not error out now when the module is not enabled. 

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
- skip coalescing null values when the module is disabled
- applies only to `local.endpoint_address` and `local.reader_endpoint_address`

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
closes #248 
