### PR TITLE
fix(serverless): Prevent empty `cache_usage_limits` block causing provider inconsistency error, update default from {} to null

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -324,7 +324,7 @@ variable "serverless_user_group_id" {
 
 variable "serverless_cache_usage_limits" {
   type        = map(any)
-  default     = {}
+  default     = null
   description = "The usage limits for the serverless cache"
 }
 


### PR DESCRIPTION
### Problem

The current default value for `serverless_cache_usage_limits` is `{}` (empty object). When this is used, the dynamic block creates an empty `cache_usage_limits` block with no nested content:

```hcl
cache_usage_limits {
}
```

AWS/the provider expects either:
- No `cache_usage_limits` block at all, OR  
- A `cache_usage_limits` block with at least one nested block (`data_storage` or `ecpu_per_second`)

This results in the following error during apply:
```
Error: Provider produced inconsistent result after apply
.cache_usage_limits: block count changed from 1 to 0.
```

### Changes

Changed the default value of `serverless_cache_usage_limits` from `{}` to `null` in `variables.tf`:

```diff
variable "serverless_cache_usage_limits" {
...
- default     = {}
+ default     = null
  description = "..."
}
```

This allows the existing dynamic block logic to correctly skip creating the block when no limits are specified:

```hcl
dynamic "cache_usage_limits" {
  for_each = try([var.serverless_cache_usage_limits], [])
  # When var is null, try() returns [], so the block is not created
```


### Issue 
Closes https://github.com/cloudposse/terraform-aws-elasticache-redis/issues/268

See [https://github.com/cloudposse/terraform-aws-elasticache-redis/issues/268](https://github.com/cloudposse/terraform-aws-elasticache-redis/issues/268) for more detail.