### PR TITLE
fix: allow auth_token_update_strategy=DELETE to migrate AUTH to RBAC/ACL

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -163,7 +163,7 @@ resource "aws_elasticache_replication_group" "default" {
   count = local.create_normal_instance ? 1 : 0
 
   auth_token                  = var.transit_encryption_enabled ? var.auth_token : null
-  auth_token_update_strategy  = var.auth_token != null ? var.auth_token_update_strategy : null
+  auth_token_update_strategy  = var.auth_token != null || upper(var.auth_token_update_strategy) == "DELETE" ? var.auth_token_update_strategy : null
   replication_group_id        = var.replication_group_id == "" ? module.this.id : var.replication_group_id
   description                 = coalesce(var.description, module.this.id)
   node_type                   = local.instance_type


### PR DESCRIPTION
## what

* Updated the ElastiCache replication group resource to allow `auth_token_update_strategy = "DELETE"` when `auth_token` is set to `null`.
* Fixed the migration path from AUTH token authentication to RBAC/ACL (`user_group_ids`) by correctly forwarding the `DELETE` strategy to AWS.
* Preserved existing behavior for resources using `SET` or `ROTATE`, as well as resources without an authentication token.

## why

* During migrations from AUTH to RBAC/ACL, AWS requires `auth_token_update_strategy = "DELETE"` to remove an existing authentication token.
* The module previously set `auth_token_update_strategy` to `null` whenever `auth_token` was `null`, preventing the provider from sending the required `DELETE` operation.
* As a result, the authentication token was never removed and Terraform applies failed, blocking the migration to RBAC/ACL.
* This change ensures that the `DELETE` strategy is passed through when explicitly requested, allowing successful token removal and completion of the migration process.
* The change is backward compatible and does not alter behavior for existing configurations using the default strategy or an active `auth_token`.

## references

* Related to ElastiCache AUTH → RBAC/ACL migration support.
* Terraform validation (`terraform validate`) and formatting (`terraform fmt`) completed successfully.
